### PR TITLE
some iterative work on the css

### DIFF
--- a/wip-portfolio.css
+++ b/wip-portfolio.css
@@ -1,14 +1,18 @@
 /*General*/
 
+p, h1, h2, h3, a, div, span {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;
+    color: #444;
+}
 p {
-    font-family: Georgia, "Times New Roman", Times, serif;
     font-size: 140%;
 }
 h2 {
+  margin-top: 60px;
 	padding-bottom: 7px;
     font-size: 190%;
 	font-weight: bold;
-	border-bottom: 1px solid #555; 
+	border-bottom: 1px solid #AAA; 
 }
 h3 {
 	font-size: 190%;
@@ -79,18 +83,35 @@ a:visited {
 #actualbody {
     margin: 0 auto;
     padding: 50px 0;
-    width: 1100px;
+    max-width: 1100px;
+    width: 90%
 }
 
 /* Project Preview*/
 .project-preview {
 	clear: both;
 	padding-bottom: .75em;
-	margin-bottom: 30px;
+	padding-top: 30px;
 }
+.project-preview p {
+  margin-top: 0px;
+}
+
+.article {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.article p {
+  margin: 0px;
+}
+
 /*Why doesn't this work?*/
-.project-preview a:hover {
-    background-color: yellow
+a:hover .project-preview, a:hover .article {
+    background-color: #FAFAFD;
+}
+
+a:hover p {
+  color: #000;
 }
 
 .project-preview .project-image img {
@@ -127,4 +148,3 @@ a:visited {
 .clearboth {
 	clear: both;
 }
-

--- a/wip-portfolio.html
+++ b/wip-portfolio.html
@@ -30,7 +30,6 @@
                     </p>
                 </div>
             </div>
-            <br class="clearboth"></br>
             <h2>Projects</h2>
             <a href="">
                 <div class="project-preview">
@@ -84,30 +83,34 @@
             <p><i>Note: sometimes I write under a pseudonym. Contact me for details.</i></p>
             <a href="">
                 <div class="article">
-                    <p><b>DNT Implementation Guide (Apache, Nginx, & Logrotate Configuration)</b><br>
-                    Electronic Frontier Foundation</p>
-                    </p>
+                    <p>
+                      <b>DNT Implementation Guide (Apache, Nginx, & Logrotate Configuration)</b><br>
+                      Electronic Frontier Foundation
+                  </p>
                 </div>
             </a>
             <a href="">
                 <div class="article">
-                    <p><b>Throttling on Mobile Networks Is a Sign of Things to Come, Unless We Save Net Neutrality Now </b><br>
-                    EFF Deeplinks Blog</p>
-                    </p>
+                    <p>
+                      <b>Throttling on Mobile Networks Is a Sign of Things to Come, Unless We Save Net Neutrality Now </b><br>
+                      EFF Deeplinks Blog
+                  </p>
                 </div>
             </a>
             <a href="">
                 <div class="article">
-                    <p><b>Limitations of ISP Data Pollution Tools</b><br>
-                    EFF Deeplinks Blog</p>
-                    </p>
+                    <p>
+                      <b>Limitations of ISP Data Pollution Tools</b><br>
+                      EFF Deeplinks Blog
+                  </p>
                 </div>
             </a>
             <a href="">
                 <div class="article">
-                    <p><b>Blockchains and voting: somewhere between hype and panacea</b><br>
-                    Submitted to <i>IEEE Computer</i></p>
-                    </p>
+                    <p>
+                      <b>Blockchains and voting: somewhere between hype and panacea</b><br>
+                      Submitted to <i>IEEE Computer</i>
+                  </p>
                 </div>
             </a>
             <h2>Miscellaneous</h2>


### PR DESCRIPTION
* Switch to sans-serif fonts
* Makes font more consistent -- `h2` font now same as main text font
* Fixes hyper link hover
* Make top of `project-preview` text align with image

![image](https://user-images.githubusercontent.com/61658/33766313-d12d4962-dbd1-11e7-9c19-e251bd90b823.png)

Note, the header is now a little different than you might expect:

![image](https://user-images.githubusercontent.com/61658/33766543-d59a502a-dbd2-11e7-8bab-2931545bec69.png)

This is because you have the `h3` font-weight set to 100 which is extra light. 

```css
h3 {
	font-size: 190%;
	font-weight: 100;
}
```

Your previous font couldn't support this very well (at least on some systems) so it looked normal, but now it comes through.
